### PR TITLE
Update cloudshell_es_install_script.sh

### DIFF
--- a/cloudshell_es_install_script.sh
+++ b/cloudshell_es_install_script.sh
@@ -46,7 +46,8 @@ install_mono () {
 		yes | yum install yum-utils
 	fi
 	# Add Mono repository
-	yum-config-manager --add-repo http://download.mono-project.com/repo/centos/
+	rpmkeys --import "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF"
+	su -c 'curl https://download.mono-project.com/repo/centos7-stable.repo | tee /etc/yum.repos.d/mono-centos7-stable.repo'
 	# Install Mono
 	yes | yum install mono-complete-5.16.0.220 --skip-broken
 	# Install required stuff to build cryptography package


### PR DESCRIPTION
changes the way we add the mono repos in order for yum to install older version (specifically 5.6.0.220). 
for some reason what we had stopped working, and so I replaced it with the official way documented in mono download documentation (https://www.mono-project.com/download/stable/#download-lin-centos)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/execution-server-cloud-installer/24)
<!-- Reviewable:end -->
